### PR TITLE
Fix aarch64 support and test in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,12 +7,28 @@ on:
 
 jobs:
   build:
-    name: build
+    name: build-${{ matrix.arch }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - amd64
+          - arm64v8
     steps:
+
+      - name: install-deps
+        run: |
+          sudo apt update
+          sudo apt install -y \
+            qemu-user-static
 
       - name: checkout
         uses: actions/checkout@v3
+
+      - name: patch-dockerfile
+        run: |
+          sed -i 's@rust:alpine@${{ matrix.arch }}/rust:alpine@' Dockerfile
 
       - name: build-image
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,4 +51,4 @@ jobs:
             rust:alpine-mimalloc \
             sh -c 'cargo install names && mv $CARGO_HOME/bin/names .'
           MIMALLOC_VERBOSE=1 ./names
-          ldd ./names
+          file ./names

--- a/README.md
+++ b/README.md
@@ -7,5 +7,7 @@ or C/C++ static executables in this image, the resulting executables
 will automatically link with `mimalloc` without needing any special
 build flags.
 
+Supported & tested archs: `amd64` and `arm64v8`.
+
 For more details, see this [blog
 post](https://www.tweag.io/blog/2023-08-10-rust-static-link-with-mimalloc).

--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,13 @@ apk upgrade --no-cache
 apk add --no-cache \
   alpine-sdk \
   cmake \
+  mold \
   samurai
+
+{
+  echo "[target.$(rustup target list --installed)]"
+  echo 'rustflags = ["-C", "link-arg=-fuse-ld=mold"]'
+} > $CARGO_HOME/config.toml
 
 curl -f -L --retry 5 https://github.com/microsoft/mimalloc/archive/refs/tags/v$MIMALLOC_VERSION.tar.gz | tar xz --strip-components=1
 


### PR DESCRIPTION
Default to using `mold` linker, which fixes a weird linker error on `aarch64`. Also test on CI using qemu user emulation. Closes #1.