### PR TITLE
Globally override default ld to ld.mold

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -14,10 +14,7 @@ apk add --no-cache \
   mold \
   samurai
 
-{
-  echo "[target.$(rustup target list --installed)]"
-  echo 'rustflags = ["-C", "link-arg=-fuse-ld=mold"]'
-} > $CARGO_HOME/config.toml
+find /usr -type f -executable -name "ld" -exec sh -c 'ln -sf /usr/bin/ld.mold {}' \;
 
 curl -f -L --retry 5 https://github.com/microsoft/mimalloc/archive/refs/tags/v$MIMALLOC_VERSION.tar.gz | tar xz --strip-components=1
 


### PR DESCRIPTION
#2 defaults rust linking to using `mold` linker by using cargo config, but it seems there are still cases that flag is not used. Just use a more brutal approach instead: globally override default `ld` to `ld.mold`.