### PR TITLE
Use alpine:latest instead of alpine:edge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:edge
+FROM alpine:latest
 
 COPY build.sh mimalloc.diff /tmp/
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `rust-alpine-mimalloc`
 
-This Docker image builds upon the `alpine:edge` image, provides
+This Docker image builds upon the `alpine:latest` image, provides
 `cargo`/`rustc` and replaces the default musl malloc implementation
 with [`mimalloc`](https://github.com/microsoft/mimalloc). If you build
 Rust or C/C++ static executables in this image, the resulting


### PR DESCRIPTION
A rare link-time error has been spotted in `alpine:edge` which should be less likely in a release version. It has to do with upstream upgrade to gcc 14 and some archives contain stale gcc 13 lto sections. In any case, the issue should be gone when the relevant archives are rebuilt, but it's a good reminder that `edge` is slightly more prone to errors like these compared to a proper rolling distro.