### PR TITLE
chore: switch to alpine:edge

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:edge
 
 COPY build.sh mimalloc.diff /tmp/
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `rust-alpine-mimalloc`
 
-This Docker image builds upon the `alpine:latest` image, provides
+This Docker image builds upon the `alpine:edge` image, provides
 `cargo`/`rustc` and replaces the default musl malloc implementation
 with [`mimalloc`](https://github.com/microsoft/mimalloc). If you build
 Rust or C/C++ static executables in this image, the resulting


### PR DESCRIPTION
rustc in alpine:3.20 is too old to compile wasmtime, hence the change.