### PR TITLE
Revert "chore: switch to alpine:edge"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:edge
+FROM alpine:latest
 
 COPY build.sh mimalloc.diff /tmp/
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `rust-alpine-mimalloc`
 
-This Docker image builds upon the `alpine:edge` image, provides
+This Docker image builds upon the `alpine:latest` image, provides
 `cargo`/`rustc` and replaces the default musl malloc implementation
 with [`mimalloc`](https://github.com/microsoft/mimalloc). If you build
 Rust or C/C++ static executables in this image, the resulting


### PR DESCRIPTION
This reverts commit 812080ac6b32642a1f3a81e2aa55e879e1457a01. alpine:latest now points to 3.21 which should work for us.