### PR TITLE
Set up default cargo config.toml

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,11 @@
+[env]
+CC = "clang"
+CXX = "clang++"
+
+[target.x86_64-alpine-linux-musl]
+linker = "clang"
+rustflags = ["-C", "target-feature=+crt-static", "-C", "link-arg=-Wl,-z,stack-size=8388608"]
+
+[target.aarch64-alpine-linux-musl]
+linker = "clang"
+rustflags = ["-C", "target-feature=+crt-static", "-C", "link-arg=-Wl,-z,stack-size=8388608"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM alpine:latest
 
-COPY build.sh mimalloc.diff /tmp/
+COPY .cargo /root/.cargo
+
+COPY build.sh mimalloc.diff /tmp
 
 RUN /tmp/build.sh
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ continue to link against `mimalloc` as intended, but you need extra
 command-line arguments to ensure they are indeed static:
 
 ```sh
-$ RUSTFLAGS="-C target-feature=+crt-static" cargo install --target x86_64-alpine-linux-musl foo
+$ cargo install --target x86_64-alpine-linux-musl foo
 ```
 
 The `--target` flag is required. The default target is either

--- a/test.sh
+++ b/test.sh
@@ -4,4 +4,4 @@ set -eu
 
 TARGET=$(rustc -vV | sed -n "s|host: ||p")
 
-RUSTFLAGS="-C target-feature=+crt-static" exec cargo install --root "$PWD" --target "$TARGET" names
+exec cargo install --root "$PWD" --target "$TARGET" names


### PR DESCRIPTION
- Default to 8M default stack size, musl's 128K default is too small
- Default to +crt-static